### PR TITLE
Fix another bug in getBestChild

### DIFF
--- a/mcts.py
+++ b/mcts.py
@@ -95,7 +95,7 @@ class mcts():
         bestValue = float("-inf")
         bestNodes = []
         for child in node.children.values():
-            nodeValue = child.totalReward / child.numVisits + explorationValue * math.sqrt(
+            nodeValue = node.state.currentPlayer * child.totalReward / child.numVisits + explorationValue * math.sqrt(
                 2 * math.log(node.numVisits) / child.numVisits)
             if nodeValue > bestValue:
                 bestValue = nodeValue


### PR DESCRIPTION
Fixes a bug in getBestChild wherein the code optimizes every move on the assumption that it's trying to get player 1 to win, which causes it to make very bad decisions in practice because it will get stuck in a node assuming the opponent will make a bad move.

Experimentation with the naughtsandcrosses.py example will make this evident; the current AI will often ignore a player threatening to win on the next move in order to place elsewhere on the board to accomplish its win, assuming the opponent won't simply win the next turn. It also causes issues where it makes intentionally bad moves if it plays as player 2.

This of course modifies the requirements slightly so that any implementation must require a state with a 'currentPlayer' variable which is 1 for player 1 and -1 for player 2, with a similar reward function that is positive for one player and negative for the other. Alternatively, you could simply record which player is the currentPlayer for the root node (1, 2, 3, or any number really), have a getReward function that is always positive, and then simply modify the getReward function based on whether or not the player that won that state is the root node current player or not.