### PR TITLE
Clearify README, add a new feature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MCTS
 
-This package provides a simple way of using Monte Carlo Tree Search in any perfect information domain.  
+This package provides a simple way of using Monte Carlo Tree Search in any perfect information domain.
 
-## Installation 
+## Installation
 
 With pip: `pip install mcts`
 
@@ -10,15 +10,15 @@ Without pip: Download the zip/tar.gz file of the [latest release](https://github
 
 ## Quick Usage
 
-In order to run MCTS, you must implement a `State` class which can fully describe the state of the world.  It must also implement four methods: 
+In order to run MCTS, you must implement a `State` class which can fully describe the state of the world.  It must also implement four methods:
 
 - `getCurrentPlayer()`: Returns 1 if it is the maximizer player's turn to choose an action, or -1 for the minimiser player
-- `getPossibleActions()`: Returns an iterable of all actions which can be taken from this state
+- `getPossibleActions()`: Returns an iterable of all `action`s which can be taken from this state
 - `takeAction(action)`: Returns the state which results from taking action `action`
-- `isTerminal()`: Returns whether this state is a terminal state
-- `getReward()`: Returns the reward for this state.  Only needed for terminal states. 
+- `isTerminal()`: Returns `True` if this state is a terminal state
+- `getReward()`: Returns the reward for this state.  Only needed for terminal states.
 
-You must also choose a hashable representation for an action as used in `getPossibleActions` and `takeAction`.  Typically this would be a class with a custom `__hash__` method, but it could also simply be a tuple or a string.  
+You must also choose a hashable representation for an action as used in `getPossibleActions` and `takeAction`.  Typically this would be a class with a custom `__hash__` method, but it could also simply be a tuple or a string.
 
 Once these have been implemented, running MCTS is as simple as initializing your starting state, then running:
 
@@ -28,7 +28,7 @@ from mcts import mcts
 mcts = mcts(timeLimit=1000)
 bestAction = mcts.search(initialState=initialState)
 ```
-See [naughtsandcrosses.py](https://github.com/pbsinclair42/MCTS/blob/master/naughtsandcrosses.py) for a simple example.  
+See [naughtsandcrosses.py](https://github.com/pbsinclair42/MCTS/blob/master/naughtsandcrosses.py) for a simple example.
 
 ## Slow Usage
 //TODO

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ from mcts import mcts
 searcher = mcts(timeLimit=1000)
 bestAction = searcher.search(initialState=initialState)
 ```
-Here the unit of `timeLimit=1000` is millisecond. You can also use `iterationLimit=1600` to specify the number of rollouts. Only and at least one in `timeLimit` and `iterationLimit` should be specified.
+Here the unit of `timeLimit=1000` is millisecond. You can also use `iterationLimit=1600` to specify the number of rollouts. Exactly one of `timeLimit` and `iterationLimit` should be specified. The expected reward of best action can be got by setting `needDetails` to `True` in `searcher`.
+
+```python
+resultDict = searcher.search(initialState=initialState, needDetails=True)
+print(resultDict.keys()) #currently includes dict_keys(['action', 'expectedReward'])
+```
 
 See [naughtsandcrosses.py](https://github.com/pbsinclair42/MCTS/blob/master/naughtsandcrosses.py) for a simple example.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ from mcts import mcts
 searcher = mcts(timeLimit=1000)
 bestAction = searcher.search(initialState=initialState)
 ```
-Here the unit of `timeLimit=1000` is ms. You can also use `iterationLimit=1600` to specify number of roolouts. Only and at least one in `timeLimit` and `iterationLimit` should be specified.
+Here the unit of `timeLimit=1000` is millisecond. You can also use `iterationLimit=1600` to specify the number of rollouts. Only and at least one in `timeLimit` and `iterationLimit` should be specified.
 
 See [naughtsandcrosses.py](https://github.com/pbsinclair42/MCTS/blob/master/naughtsandcrosses.py) for a simple example.
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Once these have been implemented, running MCTS is as simple as initializing your
 ```python
 from mcts import mcts
 
-mcts = mcts(timeLimit=1000)
-bestAction = mcts.search(initialState=initialState)
+searcher = mcts(timeLimit=1000)
+bestAction = searcher.search(initialState=initialState)
 ```
+Here the unit of `timeLimit=1000` is ms. You can also use `iterationLimit=1600` to specify number of roolouts. Only and at least one in `timeLimit` and `iterationLimit` should be specified.
+
 See [naughtsandcrosses.py](https://github.com/pbsinclair42/MCTS/blob/master/naughtsandcrosses.py) for a simple example.
 
 ## Slow Usage

--- a/mcts.py
+++ b/mcts.py
@@ -30,7 +30,7 @@ class treeNode():
         s.append("totalReward: %s"%(self.totalReward))
         s.append("numVisits: %d"%(self.numVisits))
         s.append("isTerminal: %s"%(self.isTerminal))
-        s.append("children: %s"%(self.children.keys()))
+        s.append("possibleActions: %s"%(self.children.keys()))
         return "%s: {%s}"%(self.__class__.__name__, ', '.join(s))
 
 class mcts():
@@ -53,10 +53,7 @@ class mcts():
         self.explorationConstant = explorationConstant
         self.rollout = rolloutPolicy
 
-    def search(self, initialState, needNodeValue=False):
-        """
-            do many executeRounds until the limit is reached, then return BestChild
-        """
+    def search(self, initialState, needDetails=False):
         self.root = treeNode(initialState, None)
 
         if self.limitType == 'time':
@@ -68,10 +65,9 @@ class mcts():
                 self.executeRound()
 
         bestChild = self.getBestChild(self.root, 0)
-        action,node=((action, node) for action, node in self.root.children.items() if node is bestChild).__next__()
-        if needNodeValue:
-            nodeValue = node.totalReward / node.numVisits
-            return action, nodeValue
+        action=(action for action, node in self.root.children.items() if node is bestChild).__next__()
+        if needDetails:
+            return {"action": action, "expectedReward": bestChild.totalReward / bestChild.numVisits}
         else:
             return action
 

--- a/mcts.py
+++ b/mcts.py
@@ -25,6 +25,13 @@ class treeNode():
         self.totalReward = 0
         self.children = {}
 
+    def __str__(self):
+        s=[]
+        s.append("totalReward: %s"%(self.totalReward))
+        s.append("numVisits: %d"%(self.numVisits))
+        s.append("isTerminal: %s"%(self.isTerminal))
+        s.append("children: %s"%(self.children.keys()))
+        return "%s: {%s}"%(self.__class__.__name__, ', '.join(s))
 
 class mcts():
     def __init__(self, timeLimit=None, iterationLimit=None, explorationConstant=1 / math.sqrt(2),
@@ -46,7 +53,10 @@ class mcts():
         self.explorationConstant = explorationConstant
         self.rollout = rolloutPolicy
 
-    def search(self, initialState):
+    def search(self, initialState, needNodeValue=False):
+        """
+            do many executeRounds until the limit is reached, then return BestChild
+        """
         self.root = treeNode(initialState, None)
 
         if self.limitType == 'time':
@@ -58,9 +68,17 @@ class mcts():
                 self.executeRound()
 
         bestChild = self.getBestChild(self.root, 0)
-        return self.getAction(self.root, bestChild)
+        action,node=((action, node) for action, node in self.root.children.items() if node is bestChild).__next__()
+        if needNodeValue:
+            nodeValue = node.totalReward / node.numVisits
+            return action, nodeValue
+        else:
+            return action
 
     def executeRound(self):
+        """
+            execute a selection-expansion-simulation-backpropagation round
+        """
         node = self.selectNode(self.root)
         reward = self.rollout(node.state)
         self.backpropogate(node, reward)
@@ -103,8 +121,3 @@ class mcts():
             elif nodeValue == bestValue:
                 bestNodes.append(child)
         return random.choice(bestNodes)
-
-    def getAction(self, root, bestChild):
-        for action, node in root.children.items():
-            if node is bestChild:
-                return action

--- a/naughtsandcrosses.py
+++ b/naughtsandcrosses.py
@@ -73,9 +73,9 @@ class Action():
     def __hash__(self):
         return hash((self.x, self.y, self.player))
 
+if __name__=="__main__":
+    initialState = NaughtsAndCrossesState()
+    searcher = mcts(timeLimit=1000)
+    action = searcher.search(initialState=initialState)
 
-initialState = NaughtsAndCrossesState()
-mcts = mcts(timeLimit=1000)
-action = mcts.search(initialState=initialState)
-
-print(action)
+    print(action)


### PR DESCRIPTION
Hello. We are using your MCTS for our own cards game AI project. During use, we found some unclear in README. So we add some explanations. They include,

* Specify that it is `True` stands for a terminal in `isTerminal`
* change the name of `mcts` in the example to `searcher` because `mcts` causes "UnboundLocalError: local variable 'mcts' referenced before assignment" on my machine.

I am going to write a section for "make your own rollout policy" for README later.